### PR TITLE
フッターのコピーライトの年表示を2019に修正

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,6 +1,6 @@
 .container.footer__container
   %ul.footer_links-left
-    %li.footer_link= link_to '© 2018 Matsushin Inc.', '#'
+    %li.footer_link= link_to '© 2019 Matsushin Inc.', '#'
     %li.footer_link= link_to '利用規約', '#'
     %li.footer_link= link_to 'ガイドライン', '#'
     %li.footer_link= link_to 'プライバシー', '#'


### PR DESCRIPTION
確認お願いします。（テストなし）