### PR TITLE
[WIP]ローカルとステージング環境のドメイン変更

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@
 
 development:
   secret_key_base: 2a02dd522e215677ee14ee2981c515ca2a2ffff0c937af5bce71f96d0c8e644e2ce8436ddf7be5eed63668f35a5a403ce9d668d96ff92dbc0208dce3a0a113b5
-  domain_name: qiitan.test
+  domain_name: localhost:3000
 
 test:
   secret_key_base: afe94a01e8aecc3dbd8453a76a417d806d18c892f8a72a439d0024fd3380c19d960679cf308574090edf07ca736951fbf1be319a70ed7dd0cdd7f461246d278b
@@ -31,7 +31,7 @@ test:
 
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  domain_name: qiitan-stg.herokuapp.com
+  domain_name: stg.qiitan.com
   s3:
     data_bucket: qiitan-stg
 


### PR DESCRIPTION
config/secrets.yml のdevelopmentとstagingのドメインを修正してローカルで動作確認しましたが、ドメインが```qiitan.test```になっていてメールのリンクからアクセスできませんでした。
```qiitan.test```でプロジェクト内検索かけるとconfig/secrets.ymlしかヒットしなかったので、変更箇所はここだけだと思います。
ローカル環境への反映がうまくいってないだけでしょうか？