### PR TITLE
リモートリポジトリへのPush時にビルドが通らない不具合を解消

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.3-node-browsers
+      - image: circleci/ruby:2.6.0-node-browsers
         environment:
           RAILS_ENV: test
           DATABASE_HOSTNAME: '127.0.0.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,11 @@ jobs:
             - gem-cache-{{ checksum "Gemfile.lock" }}
             - gem-cache-
       - run:
+          name: default mysql client install
+          command: |
+            sudo apt update
+            sudo apt-get install default-mysql-client
+      - run:
           name: bundle install
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       # bundle installされたものcacheする

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.0-node-browsers
+      - image: circleci/ruby:2.6.3-node-browsers
         environment:
           RAILS_ENV: test
           DATABASE_HOSTNAME: '127.0.0.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.5.5-node-browsers
+      - image: circleci/ruby:2.6.0-node-browsers
         environment:
           RAILS_ENV: test
           DATABASE_HOSTNAME: '127.0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     public_suffix (3.1.0)
     puma (3.12.0)
     rack (2.0.7)
-    rack-dev-mark (0.7.7)
+    rack-dev-mark (0.7.8)
       rack (>= 1.1, < 2.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:11.13.0-stretch-slim as node
-FROM ruby:2.5.5-slim-stretch
+FROM ruby:2.6.3-slim-stretch
 
 ENV LANG C.UTF-8
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:11.13.0-stretch-slim as node
-FROM ruby:2.6.3-slim-stretch
+FROM ruby:2.5.5-slim-stretch
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
## 経緯
1. .circleci/config.ymlに、default-mysql-clientのインストールを追記
  - ビルド失敗(db:createでエラー)
2. .circleci/config.ymlのdocker imageのRubyのバージョンを2.5.5→2.6.0（その間がなかった）に変更
  - ビルド失敗(gem rack-dev-mark(0.7.7)がRuby2.6.0に対応していないため、bundle installでエラー)
3. $ docker-compose run web bundle update rack-dev-mark でrack-dev-markのバージョンアップ
  - ビルド成功

## 懸念点
- Rubyのバージョンアップによる影響範囲がわからない。
- Rubyのバージョンがdockerfileは2.5.5、.circleci/config.ymlのdocker imageは2.6.0で揃っていない。