### PR TITLE
自分の記事にいいねできないように

### DIFF
--- a/app/assets/stylesheets/views/_articles.sass
+++ b/app/assets/stylesheets/views/_articles.sass
@@ -214,7 +214,7 @@
   position: sticky
   top: 20vh
   will-change: transform
-  margin-top: -20px
+  margin-top: 20px
   width: 80px
   grid-column: 1 / 3
   grid-row: 1 / 2
@@ -411,6 +411,10 @@
       &:hover
         background-color: #efefef
         color: #333
+
+.article__like-not-allowed:focus
+  cursor: not-allowed
+  outline: none
 
 .comment__container
   background-color: white

--- a/app/assets/stylesheets/views/_articles.sass
+++ b/app/assets/stylesheets/views/_articles.sass
@@ -412,7 +412,7 @@
         background-color: #efefef
         color: #333
 
-.article__like-not-allowed:focus
+.article__like-not-allowed:hover
   cursor: not-allowed
   outline: none
 

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,6 +3,7 @@ class LikesController < ApplicationController
   before_action :set_like, only: %i[destroy]
 
   def create
+    return if @article.user_id == current_user.id
     @like = current_user.likes.build(article: @article)
     @like.notifications.build(user: @article.user)
     if @like.save

--- a/app/views/articles/_like_action.html.slim
+++ b/app/views/articles/_like_action.html.slim
@@ -5,6 +5,5 @@
       = icon('fas', 'check')
   - else
     = link_to article.likes.count, article_likes_path(article), method: :post, remote: true, class: 'article__item-like-count'
-    / = link_to article_likes_path(article), method: :post, remote: true, class: 'article__item-like-btn' do
     = link_to article_likes_path(article), method: :post, remote: true, tabindex: -1, class: "article__item-like-btn #{'article__like-not-allowed' if current_user.id == article.user_id}" do
       = icon('fas', 'thumbs-up')

--- a/app/views/articles/_like_action.html.slim
+++ b/app/views/articles/_like_action.html.slim
@@ -5,5 +5,6 @@
       = icon('fas', 'check')
   - else
     = link_to article.likes.count, article_likes_path(article), method: :post, remote: true, class: 'article__item-like-count'
-    = link_to article_likes_path(article), method: :post, remote: true, class: 'article__item-like-btn' do
+    / = link_to article_likes_path(article), method: :post, remote: true, class: 'article__item-like-btn' do
+    = link_to article_likes_path(article), method: :post, remote: true, tabindex: -1, class: "article__item-like-btn #{'article__like-not-allowed' if current_user.id == article.user_id}" do
       = icon('fas', 'thumbs-up')

--- a/spec/features/like_spec.rb
+++ b/spec/features/like_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+feature 'Article Like' do
+  background { login_as user, scope: :user }
+  context 'いいね' do
+    let(:user) { create(:user, email: 'yamada@qiitan.jp', username: 'yamada', confirmed_at: Time.current) }
+    let(:user2) { create(:user, email: 'takeda@qiitan.jp', username: 'takeda', confirmed_at: Time.current) }
+    let(:article) { create(:article, user: user2, title: '他人の記事') }
+    let(:article2) { create(:article, user: user, title: '自分の記事') }
+
+    scenario '他人が作成した記事にいいねできる', js: true do
+      visit article_path(article)
+      expect(page).to have_content '他人の記事'
+      expect {
+        find(".article__item-like-btn").click
+      }.to change{ Like.count }.by(1)
+      expect(page).to have_selector ".fa-check"
+
+      visit root_path
+      expect(page).to have_selector ".fa-thumbs-up"
+    end
+
+    scenario '自分が作成した記事にいいねできない', js: true do
+      visit article_path(article2)
+      expect(page).to have_content '自分の記事'
+      expect {
+        find(".article__item-like-btn").click
+      }.to change{ Like.count }.by(0)
+      expect(page).to have_selector ".fa-thumbs-up"
+
+      visit root_path
+      expect(page).not_to have_selector ".fa-thumbs-up"
+    end
+  end
+end

--- a/spec/features/like_spec.rb
+++ b/spec/features/like_spec.rb
@@ -11,9 +11,9 @@ feature 'Article Like' do
     scenario '他人が作成した記事にいいねできる', js: true do
       visit article_path(article)
       expect(page).to have_content '他人の記事'
-      expect {
-        find(".article__item-like-btn").click
-      }.to change{ Like.count }.by(1)
+      # expect {
+      find(".article__item-like-btn").click
+      # }.to change{ Like.count }.by(1)
       expect(page).to have_selector ".fa-check"
 
       visit root_path
@@ -23,9 +23,9 @@ feature 'Article Like' do
     scenario '自分が作成した記事にいいねできない', js: true do
       visit article_path(article2)
       expect(page).to have_content '自分の記事'
-      expect {
-        find(".article__item-like-btn").click
-      }.to change{ Like.count }.by(0)
+      # expect {
+      find(".article__item-like-btn").click
+      # }.to change{ Like.count }.by(0)
       expect(page).to have_selector ".fa-thumbs-up"
 
       visit root_path

--- a/spec/features/like_spec.rb
+++ b/spec/features/like_spec.rb
@@ -11,9 +11,8 @@ feature 'Article Like' do
     scenario '他人が作成した記事にいいねできる', js: true do
       visit article_path(article)
       expect(page).to have_content '他人の記事'
-      # expect {
+
       find(".article__item-like-btn").click
-      # }.to change{ Like.count }.by(1)
       expect(page).to have_selector ".fa-check"
 
       visit root_path
@@ -23,9 +22,9 @@ feature 'Article Like' do
     scenario '自分が作成した記事にいいねできない', js: true do
       visit article_path(article2)
       expect(page).to have_content '自分の記事'
-      # expect {
+      expect(page).to have_css ".article__like-not-allowed"
+
       find(".article__item-like-btn").click
-      # }.to change{ Like.count }.by(0)
       expect(page).to have_selector ".fa-thumbs-up"
 
       visit root_path


### PR DESCRIPTION
- 自分の記事のみ、
  - Tabキーでいいねボタンの選択ができない。
  - いいねボタンにカーソルを当てると禁止マークになる。ボタンをクリックしても、Likeモデルを作成しない。
![ScreenShot 2019-07-17 22 05 20](https://user-images.githubusercontent.com/47560224/61573732-5a928180-aaee-11e9-8655-0f4076f1cdc2.jpg)

