### PR TITLE
ヘッダーの通知表示の崩れた見た目を修正

### DIFF
--- a/app/assets/stylesheets/views/_notifications.sass
+++ b/app/assets/stylesheets/views/_notifications.sass
@@ -38,6 +38,7 @@
   right: 0
   z-index: 1000
   width: 320px
+  height: 480px
   background-color: white
   padding: 16px 0
   border: 1px solid #ddd
@@ -56,6 +57,7 @@
 .notification-widget-body
   width: 100%
   height: calc(100% - 50px)
+  overflow: scroll  
 
 .notifications__widget-item-container
   padding: 8px
@@ -75,7 +77,7 @@
   justify-content: center
   color: $black
   font-size: 1.2rem
-  padding: 16px 16px 0 16px
+  padding: 0 16px
   height: 30px
   a
     color: inherit

--- a/app/assets/stylesheets/views/_notifications.sass
+++ b/app/assets/stylesheets/views/_notifications.sass
@@ -40,7 +40,7 @@
   width: 320px
   height: 480px
   background-color: white
-  padding: 16px 0
+  padding: 16px 16px 0 16px
   border: 1px solid #ddd
   border-radius: 3px
   box-shadow: 0 0 8px 0 rgba(0,0,0,.15)
@@ -57,7 +57,7 @@
 .notification-widget-body
   width: 100%
   height: calc(100% - 50px)
-  overflow: scroll  
+  overflow: scroll
 
 .notifications__widget-item-container
   padding: 8px

--- a/app/assets/stylesheets/views/_notifications.sass
+++ b/app/assets/stylesheets/views/_notifications.sass
@@ -38,7 +38,6 @@
   right: 0
   z-index: 1000
   width: 320px
-  height: 480px
   background-color: white
   padding: 16px 0
   border: 1px solid #ddd
@@ -76,7 +75,7 @@
   justify-content: center
   color: $black
   font-size: 1.2rem
-  padding: 0 16px
+  padding: 16px 16px 0 16px
   height: 30px
   a
     color: inherit


### PR DESCRIPTION
## Issue
#49

## 対応
ヘッダーの各通知の合計行数が一定以上になると、「通知一覧を見る」リンクが各通知に重なって表示される不具合を修正。

## 画面
![ScreenShot 2019-09-08 9 08 59](https://user-images.githubusercontent.com/47560224/64481583-585cc180-d219-11e9-88e2-15293ae609f2.jpg)
