### PR TITLE
Fix design2

### DIFF
--- a/app/assets/stylesheets/shared/_common.sass
+++ b/app/assets/stylesheets/shared/_common.sass
@@ -4,6 +4,7 @@ $long-width: 350px
 
 body
   font-family: $font-family
+  background-color: $gray-little
 
 main
   &.main__navigation

--- a/app/assets/stylesheets/views/_home.sass
+++ b/app/assets/stylesheets/views/_home.sass
@@ -1,6 +1,11 @@
+.home__article
+  background-color: white
+  padding: 10px
+  margin-top: 30px
+
 .home__user-container
+  background-color: white
   margin-top: 78px
-  border: 1px solid $gray
   color: $black
   padding-bottom: 15px
   padding-top: 15px
@@ -8,13 +13,11 @@
     border-radius: 50%
 
 .home__user-container-stats
+  background-color: white
   text-align: center
 
 .home__user-container-stat
-  border-bottom: 1px solid $gray
-  border-left: 1px solid $gray
-  border-right: 1px solid $gray
-  border-top: 3px solid $base-color
+  background-color: white
   color: $black
   padding-bottom: 10px
   padding-top: 5px
@@ -24,7 +27,11 @@
   font-weight: 600
   color: $black
 
+.home__user-container-title
+  color: gray
+
 .home__user-name
-  font-size: 1.4em
+  font-size: 1.0em
   font-weight: 500
-  color: $black
+  color: gray
+  line-height: 48px

--- a/app/assets/stylesheets/views/_users.sass
+++ b/app/assets/stylesheets/views/_users.sass
@@ -11,6 +11,9 @@
     left: 110px
     top: 15px
     padding: 10px
+    .dropdown-item
+      color: gray
+      text-decoration: none
 
 .user__profile-image
   margin-bottom: 20px

--- a/app/assets/stylesheets/views/_users.sass
+++ b/app/assets/stylesheets/views/_users.sass
@@ -58,6 +58,7 @@
 
 .title
   margin-top: 20px
+  margin-left: 7px
   font-size: 18px
   font-weight: bold
   .fa-square-full

--- a/app/assets/stylesheets/views/_users.sass
+++ b/app/assets/stylesheets/views/_users.sass
@@ -1,6 +1,14 @@
 .user-row
   margin-top: 20px
 
+.user__profile
+  background-color: white
+  padding: 20px
+
+.user__article
+  background-color: white
+  padding: 20px
+
 .user__profile-menu
   position:  relative
   i

--- a/app/assets/stylesheets/views/_users.sass
+++ b/app/assets/stylesheets/views/_users.sass
@@ -17,24 +17,37 @@
 
 .user__profile-image
   margin-bottom: 20px
+  margin-top: 30px
+  text-align: center
   img
     display: inline-block
     line-height: 1
     vertical-align: middle
     border-radius: 6px
     overflow: hidden
-    width: 100%
+    width: 60px
     border-radius: 50%
+
+.user-name
+  font-size: 15px
+  text-align: center
+  color: gray
 
 .user__activity-stats
   margin: 0 0 10px
   text-align: center
+  .user__activity-stat_count
+    font-size: 25px
+    font-weight: lighter
+  .user__activity-stat_title
+    color: gray
+
+.user__profile-edit
+  width: 100%
+  background-color: gray
+  color: white
 
 .user__activity-stat
-  border-bottom: 1px solid $gray
-  border-left: 1px solid $gray
-  border-right: 1px solid $gray
-  border-top: 3px solid $base-color
   color: $black
   padding-bottom: 15px
   padding-top: 10px

--- a/app/assets/stylesheets/views/_users.sass
+++ b/app/assets/stylesheets/views/_users.sass
@@ -44,10 +44,10 @@
 .user__activity-stats
   margin: 0 0 10px
   text-align: center
-  .user__activity-stat_count
+  .user__activity-stat-count
     font-size: 25px
     font-weight: lighter
-  .user__activity-stat_title
+  .user__activity-stat-title
     color: gray
 
 .user__profile-edit
@@ -60,7 +60,7 @@
   padding-bottom: 15px
   padding-top: 10px
 
-.user__activity-stat_count
+.user__activity-stat-count
   font-size: 2em
   font-weight: 700
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,10 +1,11 @@
 .row
   .col-md-8
-    h2.page__title
-      = icon('far', 'file-alt')
-      | すべての投稿
-    = render 'shared/articles/index', articles: @articles
-  .col-md-4
+    .home__article
+      h2.page__title
+        = icon('far', 'file-alt')
+        | すべての投稿
+      = render 'shared/articles/index', articles: @articles
+  .col-md-4.home__user
     .row.d-flex.home__user-container
       .col-md-2
         = image_tag current_user.profile_image.thumb.url, class: 'media__image thumb thumb-m'
@@ -14,8 +15,8 @@
       .col-md-6.home__user-container-stat
         = link_to current_user.articles.count, user_path(current_user), class: 'home__user-container-count articles-count'
         br
-        | Items
+        .home__user-container-title 記事
       .col-md-6.home__user-container-stat
         span.contributtion-count.home__user-container-count= Like.where(article: current_user.articles).count
         br
-        | Contributtion
+        .home__user-container-title Contributtion

--- a/app/views/shared/articles/_index.html.slim
+++ b/app/views/shared/articles/_index.html.slim
@@ -16,7 +16,7 @@
             a.lgtm-mark LGTM
             a.lgtm-count= article.likes.count
           - if !liked_articles_request?
-            a.time-status= I18n.localize(article.created_at.to_date)
+            a.time-status= I18n.l(article.created_at.to_date)
   = paginate articles
 - else
   p 記事が1つもありません。

--- a/app/views/shared/articles/_index.html.slim
+++ b/app/views/shared/articles/_index.html.slim
@@ -16,7 +16,8 @@
             a.lgtm-mark LGTM
             a.lgtm-count= article.likes.count
           - if !liked_articles_request?
-            a.time-status= article.created_at.to_date
+            / a.time-status= article.created_at.to_date
+            a.time-status= I18n.localize(article.created_at.to_date)
   = paginate articles
 - else
   p 記事が1つもありません。

--- a/app/views/shared/articles/_index.html.slim
+++ b/app/views/shared/articles/_index.html.slim
@@ -16,7 +16,6 @@
             a.lgtm-mark LGTM
             a.lgtm-count= article.likes.count
           - if !liked_articles_request?
-            / a.time-status= article.created_at.to_date
             a.time-status= I18n.localize(article.created_at.to_date)
   = paginate articles
 - else

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -9,13 +9,13 @@
     h3.user-name= @user.username
     .row.user__activity-stats
       .col-xs-6.user__activity-stat
-        span.user__activity-stat_count= @user.articles.count
+        span.user__activity-stat-count= @user.articles.count
         br
-        span.user__activity-stat_title 投稿
+        span.user__activity-stat-title 投稿
       .col-xs-6.user__activity-stat
-        span.user__activity-stat_count= Like.where(article: @user.articles).count
+        span.user__activity-stat-count= Like.where(article: @user.articles).count
         br
-        span.user__activity-stat_title Contributtion
+        span.user__activity-stat-title Contributtion
     = link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user__profile-edit btn btn-default'
       
   .col-md-9.col-sm-9.col-xs-12

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,5 +1,5 @@
 .row.user-row
-  .col-md-3.col-sm-3.col-xs-12
+  .col-md-3.col-sm-3.col-xs-12.user__profile
     .dropdown.user__profile-menu
       i.fa.fa-ellipsis-h.fa-lg.dropdown-toggle#dropdown1 tabindex='0' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'
       .dropdown-menu aria-labelledby='dropdown1'
@@ -19,10 +19,11 @@
     = link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user__profile-edit btn btn-default'
       
   .col-md-9.col-sm-9.col-xs-12
-    div class="title #{liked_articles_request? ? 'hidden' : 'active'}"
-      i.fas.fa-square-full
-      a 全ての記事
-    div class="title #{liked_articles_request? ? 'active' : 'hidden'}"
-      i.fas.fa-square-full
-      a LGTMした記事
-    = render 'shared/articles/index', articles: @articles, hide_username: true
+    .user__article
+      div class="title #{liked_articles_request? ? 'hidden' : 'active'}"
+        i.fas.fa-square-full
+        a 全ての記事
+      div class="title #{liked_articles_request? ? 'active' : 'hidden'}"
+        i.fas.fa-square-full
+        a LGTMした記事
+      = render 'shared/articles/index', articles: @articles, hide_username: true

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -6,17 +6,19 @@
         = link_to 'LGTMした記事', show_user_path(@user, liked: :liked), class: 'dropdown-item'
     .user__profile-image
       = image_tag @user.profile_image.thumb.url
-    h3= @user.username
-  .col-md-9.col-sm-9.col-xs-12
+    h3.user-name= @user.username
     .row.user__activity-stats
       .col-xs-6.user__activity-stat
         span.user__activity-stat_count= @user.articles.count
         br
-        | Items
+        span.user__activity-stat_title 投稿
       .col-xs-6.user__activity-stat
         span.user__activity-stat_count= Like.where(article: @user.articles).count
         br
-        | Contributtion
+        span.user__activity-stat_title Contributtion
+    = link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user__profile-edit btn btn-default'
+      
+  .col-md-9.col-sm-9.col-xs-12
     div class="title #{liked_articles_request? ? 'hidden' : 'active'}"
       i.fas.fa-square-full
       a 全ての記事

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -8,7 +8,7 @@ feature 'Home' do
   context 'Home User Container' do
     let(:user) { create(:user, email: 'test@example.com', username: 'test_user', confirmed_at: Time.current) }
 
-    scenario 'HOME画面の自分の「Items(記事数)」の表示の確認', js: true do
+    scenario 'HOME画面の自分の「記事」の表示の確認', js: true do
       visit root_path
       expect(page).to have_selector '.articles-count', text: '2'
     end
@@ -20,14 +20,14 @@ feature 'Home' do
 
     scenario 'HOME画面の自分の「ユーザー名」からユーザー詳細画面に遷移できる', js: true do
       visit root_path
-      expect(page).to have_content 'Items'
+      expect(page).to have_content '記事'
       find(".home__user-name").click
       expect(current_path).to eq user_path(user)
     end
 
     scenario 'HOME画面の自分の「投稿記事数」からユーザー詳細画面に遷移できる', js: true do
       visit root_path
-      expect(page).to have_content 'Items'
+      expect(page).to have_content '記事'
       find(".articles-count").click
       expect(current_path).to eq user_path(user)
     end


### PR DESCRIPTION
Close #92 
マイページ画面のデザインをQiitaに合わせる変更を行いました。

【変更前画像】

<img width="1210" alt="スクリーンショット 2020-07-19 16 50 28" src="https://user-images.githubusercontent.com/61367038/87872023-54303180-c9f0-11ea-8c0e-dfebfe2f4dd2.png">
<img width="221" alt="スクリーンショット 2020-07-19 16 42 55" src="https://user-images.githubusercontent.com/61367038/87872084-bb4de600-c9f0-11ea-9899-c7391231c8c8.png">

【変更後画像】

<img width="1233" alt="スクリーンショット 2020-07-19 18 59 51" src="https://user-images.githubusercontent.com/61367038/87872285-0e746880-c9f2-11ea-9f7b-356dae05820b.png">

【具体的な変更点】

①LGTMした記事のメニューの色を変更

<img width="202" alt="スクリーンショット 2020-07-19 16 43 11" src="https://user-images.githubusercontent.com/61367038/87872236-bb9ab100-c9f1-11ea-983a-ee185ba8a0f3.png">

②サイドメニューの見た目調整
投稿とContributtionをサイドメニューに移動した他、デザインを調整

<img width="312" alt="スクリーンショット 2020-07-19 17 36 33" src="https://user-images.githubusercontent.com/61367038/87872276-f43a8a80-c9f1-11ea-8ffb-8500006da62a.png">

③記事の日付の形式を変更

<img width="126" alt="スクリーンショット 2020-07-19 17 41 07" src="https://user-images.githubusercontent.com/61367038/87872312-3d8ada00-c9f2-11ea-93e4-ba3a350c695a.png">

④「全ての記事」のタイトル位置を調整
一連の記事と縦に揃うように調整

<img width="313" alt="スクリーンショット 2020-07-19 17 45 13" src="https://user-images.githubusercontent.com/61367038/87872322-50051380-c9f2-11ea-876f-b0a07c6d0b7b.png">

⑤背景を灰色に設定
コンテンツの背景は白で残して設定

【その他】
Rspecを一部変更してテストが通るように修正